### PR TITLE
changed cGLD to CELO

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -5,7 +5,7 @@
 #include "cx.h"
 
 #define CHAINID_UPCASE "CELO"
-#define CHAINID_COINNAME "cGLD"
+#define CHAINID_COINNAME "CELO"
 #define CHAIN_ID 0
 
 typedef union {


### PR DESCRIPTION
Renamed cGLD to CELO in the spend app in conformity with the rename of the cGLD asset to CELO